### PR TITLE
Download model at compiletime 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "aperature"
 version = "0.1.0"
 authors = ["Mason Stallmo <masonstallmo@gmail.com>"]
 edition = "2018"
+build = "build.rs"
 license = "MIT"
 description = "Object detection using single shot multibox detector"
 readme = "README.md"
@@ -19,3 +20,8 @@ image = "0.20.1"
 ndarray = "0.12.1"
 imageproc = "0.17.0"
 hashbrown = "0.1.7"
+
+[build-dependencies]
+reqwest = "0.9.6"
+tar = "0.4.20"
+flate2 = "1.0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Object detection using single shot multibox detector"
 readme = "README.md"
 keywords = ["computer", "vision", "tensorflow", "object", "detection"]
 repository = "https://github.com/mstallmo/aperature"
-exclude = ["test_output.jpg"]
+exclude = ["test_output.jpg", "models/*"]
 
 [badges]
 travis-ci = { repository = "https://github.com/mstallmo/aperature", branch = "master" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,38 @@
+use flate2::read::GzDecoder;
+use reqwest;
+use std::fs::File;
+use std::io::copy;
+use std::path::Path;
+use tar::Archive;
+
+fn main() {
+    if !Path::new("./models/ssd_mobilenet_v1_coco_2017_11_17/frozen_inference_graph.pb").exists() {
+        download_model("./models/ssd_mobilenet_v1_coco_2017_11_17.tar.gz");
+    }
+}
+
+fn download_model<P: AsRef<Path>>(destination: P) {
+    println!("Downloading model...");
+
+    let file_path = Path::new(destination.as_ref());
+    let mut response = reqwest::get("http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2017_11_17.tar.gz").unwrap();
+    let mut dest = {
+        std::fs::create_dir_all("./models").unwrap();
+        File::create(file_path).unwrap()
+    };
+    copy(&mut response, &mut dest).unwrap();
+
+    unzip_archive(file_path).unwrap();
+    std::fs::remove_file(file_path).unwrap();
+
+    println!("Download finished!");
+}
+
+fn unzip_archive<P: AsRef<Path>>(file_path: P) -> Result<(), std::io::Error> {
+    println!("Unzipping file...");
+    let tar = GzDecoder::new(File::open(file_path)?);
+    let mut archive = Archive::new(tar);
+    archive.unpack("./models")?;
+    println!("Unzipping complete!");
+    Ok(())
+}


### PR DESCRIPTION
closes #3

So it turns out that crates.io was very unhappy about including the `frozen_graph.pb` with the 
pubished crate. Because of that I reverted the commit removing the old download code and excluded the 
model folder from upload to crates.io. I would like to keep the model checked into the repo as a way to 
keep track of supported versions but when users download the crate for compilation they will have to 
download it on the first compile.

I would like to slim down the download payload in the future so that we don't have to pull down the 
entire serialized graph but just the frozen model we're going to use for inference. Will make another
issue for tackling that.